### PR TITLE
KO - Hoehensatz Grafikgroesse Korrektur

### DIFF
--- a/Chap5/Hoehensatz.tikz.tex
+++ b/Chap5/Hoehensatz.tikz.tex
@@ -1,8 +1,8 @@
 \tdplotsetmaincoords{0}{0} %-27
  	\begin{tikzpicture}[yscale=1,tdplot_main_coords]
 
- 		\def\xstart{0} %x Koordinate der Startposition der Grafik
- 		\def\ystart{0} %y Koordinate der Startposition der Grafik
+ 		\def\xstart{-1.0} %x Koordinate der Startposition der Grafik
+ 		\def\ystart{-1.9} %y Koordinate der Startposition der Grafik
  		\def\myscale{1.0} %ändert die Größe der Grafik (Skalierung der Grafik)
         \def\myscalex{(\myscale)}
         \def\myscaley{(\myscale)}


### PR DESCRIPTION
Habe jetzt die Grafik etwas verschoben, nun sollte der Abstand weniger sein. Habe mir dazu einen Rahmen eingeblendet.
![tikz_grafikgroesse](https://cloud.githubusercontent.com/assets/15906840/15827457/82ca65f6-2c0b-11e6-8bac-e071cdd952a7.PNG)

Original hat es so ausgesehen:
![tikz_grafikgroesse02](https://cloud.githubusercontent.com/assets/15906840/15827902/7f27bcb2-2c0d-11e6-93e0-c888bb229183.PNG)
